### PR TITLE
Implement Connect Numbers puzzle game

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Connect Numbers</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },
-  "devDependencies": {},
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.2.1",
+    "vite": "^5.2.0"
+  },
   "type": "module"
 }

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "connect-numbers",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "node --test"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {},
+  "type": "module"
+}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,0 +1,270 @@
+import { useEffect, useMemo, useState } from 'react';
+import Board from './components/Board.jsx';
+import HUD from './components/HUD.jsx';
+import Controls from './components/Controls.jsx';
+import { generatePuzzle } from './utils/generator.js';
+import { calculatePathSum, isValidNextSelection } from './utils/pathUtils.js';
+import './styles/app.css';
+
+const LEVEL_CONFIGS = [
+  {
+    gridSize: 4,
+    targetRange: [8, 15],
+    timeLimit: 90,
+    requiredSolutions: 5,
+    features: {
+      negative: false,
+      locked: false,
+      bonus: false
+    }
+  },
+  {
+    gridSize: 5,
+    targetRange: [12, 25],
+    timeLimit: 75,
+    requiredSolutions: 6,
+    features: {
+      negative: true,
+      locked: false,
+      bonus: false
+    }
+  },
+  {
+    gridSize: 6,
+    targetRange: [18, 35],
+    timeLimit: 60,
+    requiredSolutions: 7,
+    features: {
+      negative: true,
+      locked: true,
+      bonus: true
+    }
+  }
+];
+
+const LOCAL_STORAGE_KEYS = {
+  bestScore: 'connect_numbers_best_score',
+  bestLevel: 'connect_numbers_best_level'
+};
+
+// Audio hooks can be implemented later. Stubs are provided so the rest of the
+// app can call them without errors if sounds are introduced.
+const playSuccessSound = () => {};
+const playErrorSound = () => {};
+
+function App() {
+  const [levelIndex, setLevelIndex] = useState(0);
+  const [grid, setGrid] = useState([]);
+  const [target, setTarget] = useState(0);
+  const [selectedPath, setSelectedPath] = useState([]);
+  const [score, setScore] = useState(0);
+  const [streak, setStreak] = useState(0);
+  const [timeLeft, setTimeLeft] = useState(LEVEL_CONFIGS[0].timeLimit);
+  const [solvedCount, setSolvedCount] = useState(0);
+  const [isPaused, setIsPaused] = useState(false);
+  const [hudShake, setHudShake] = useState(false);
+  const [bestScore, setBestScore] = useState(() => {
+    const stored = window.localStorage.getItem(LOCAL_STORAGE_KEYS.bestScore);
+    return stored ? Number(stored) : 0;
+  });
+  const [bestLevel, setBestLevel] = useState(() => {
+    const stored = window.localStorage.getItem(LOCAL_STORAGE_KEYS.bestLevel);
+    return stored ? Number(stored) : 1;
+  });
+
+  const levelConfig = LEVEL_CONFIGS[levelIndex];
+
+  useEffect(() => {
+    const { grid: newGrid, target: newTarget } = generatePuzzle(levelConfig);
+    setGrid(newGrid);
+    setTarget(newTarget);
+    setSelectedPath([]);
+  }, [levelConfig]);
+
+  useEffect(() => {
+    setTimeLeft(levelConfig.timeLimit);
+  }, [levelConfig]);
+
+  useEffect(() => {
+    if (isPaused) {
+      return undefined;
+    }
+    if (timeLeft <= 0) {
+      return undefined;
+    }
+    const interval = window.setInterval(() => {
+      setTimeLeft((prev) => {
+        if (prev <= 1) {
+          window.clearInterval(interval);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+    return () => window.clearInterval(interval);
+  }, [isPaused, timeLeft]);
+
+  useEffect(() => {
+    if (timeLeft === 0) {
+      handleGameOver();
+    }
+  }, [timeLeft]);
+
+  useEffect(() => {
+    window.localStorage.setItem(LOCAL_STORAGE_KEYS.bestScore, String(bestScore));
+  }, [bestScore]);
+
+  useEffect(() => {
+    window.localStorage.setItem(LOCAL_STORAGE_KEYS.bestLevel, String(bestLevel));
+  }, [bestLevel]);
+
+  const runningSum = useMemo(() => {
+    return calculatePathSum(selectedPath, grid);
+  }, [selectedPath, grid]);
+
+  const handleSelectTile = (row, col) => {
+    if (timeLeft <= 0 || isPaused) {
+      return;
+    }
+    const tile = grid[row]?.[col];
+    if (!tile || tile.locked) {
+      return;
+    }
+
+    const last = selectedPath[selectedPath.length - 1];
+    if (last && last.row === row && last.col === col) {
+      setSelectedPath((prev) => prev.slice(0, -1));
+      return;
+    }
+
+    const alreadySelected = selectedPath.some((pos) => pos.row === row && pos.col === col);
+    if (alreadySelected) {
+      return;
+    }
+
+    if (selectedPath.length === 0 || isValidNextSelection(selectedPath[selectedPath.length - 1], { row, col })) {
+      setSelectedPath((prev) => [...prev, { row, col }]);
+    }
+  };
+
+  const handleSubmitPath = () => {
+    if (selectedPath.length === 0 || timeLeft <= 0) {
+      return;
+    }
+    if (runningSum === target) {
+      const lengthBonus = selectedPath.length * 10;
+      const streakBonus = streak * 5;
+      const gained = lengthBonus + streakBonus;
+      const newScore = score + gained;
+      setScore(newScore);
+      const newStreak = streak + 1;
+      setStreak(newStreak);
+      const newSolved = solvedCount + 1;
+      setSolvedCount(newSolved);
+      const required = levelConfig.requiredSolutions;
+      const unlockedLevel =
+        newSolved >= required && levelIndex < LEVEL_CONFIGS.length - 1
+          ? levelIndex + 2
+          : levelIndex + 1;
+      updateBests(newScore, unlockedLevel);
+      advanceOrRefresh(newSolved);
+      playSuccessSound();
+    } else {
+      setStreak(0);
+      setHudShake(true);
+      window.setTimeout(() => setHudShake(false), 400);
+      playErrorSound();
+    }
+    setSelectedPath([]);
+  };
+
+  const advanceOrRefresh = (newSolved) => {
+    const required = levelConfig.requiredSolutions;
+    if (newSolved >= required) {
+      if (levelIndex < LEVEL_CONFIGS.length - 1) {
+        setLevelIndex((prev) => prev + 1);
+        setSolvedCount(0);
+      } else {
+        // Completed final level; increase difficulty loop by resetting solved count and refreshing board.
+        setSolvedCount(0);
+        refreshPuzzle();
+      }
+    } else {
+      refreshPuzzle();
+    }
+  };
+
+  const refreshPuzzle = () => {
+    const { grid: newGrid, target: newTarget } = generatePuzzle(levelConfig);
+    setGrid(newGrid);
+    setTarget(newTarget);
+  };
+
+  const handleReset = () => {
+    setLevelIndex(0);
+    setScore(0);
+    setStreak(0);
+    setSolvedCount(0);
+    setIsPaused(false);
+    setTimeLeft(LEVEL_CONFIGS[0].timeLimit);
+    const { grid: newGrid, target: newTarget } = generatePuzzle(LEVEL_CONFIGS[0]);
+    setGrid(newGrid);
+    setTarget(newTarget);
+    setSelectedPath([]);
+  };
+
+  const handlePauseToggle = () => {
+    setIsPaused((prev) => !prev);
+  };
+
+  const handleGameOver = () => {
+    setIsPaused(true);
+  };
+
+  const updateBests = (newScore, reachedLevel) => {
+    if (newScore > bestScore) {
+      setBestScore(newScore);
+    }
+    if (reachedLevel > bestLevel) {
+      setBestLevel(reachedLevel);
+    }
+  };
+
+  const handleUndo = () => {
+    setSelectedPath((prev) => prev.slice(0, -1));
+  };
+
+  const gameState = {
+    grid,
+    target,
+    selectedPath,
+    score,
+    level: levelIndex + 1,
+    streak,
+    timeLeft,
+    runningSum,
+    bestScore,
+    bestLevel,
+    required: levelConfig.requiredSolutions,
+    solvedCount,
+    isPaused
+  };
+
+  return (
+    <div className="app">
+      <h1>Connect Numbers</h1>
+      <HUD {...gameState} shake={hudShake} />
+      <Board grid={grid} selectedPath={selectedPath} onSelect={handleSelectTile} />
+      <Controls
+        onSubmit={handleSubmitPath}
+        onUndo={handleUndo}
+        onReset={handleReset}
+        onPauseToggle={handlePauseToggle}
+        isPaused={isPaused}
+        canSubmit={selectedPath.length > 0 && !isPaused && timeLeft > 0}
+      />
+    </div>
+  );
+}
+
+export default App;

--- a/src/components/Board.jsx
+++ b/src/components/Board.jsx
@@ -1,0 +1,28 @@
+import Tile from './Tile.jsx';
+import './board.css';
+
+function Board({ grid, selectedPath, onSelect }) {
+  const columnCount = grid[0]?.length || grid.length || 0;
+  return (
+    <div className="board" style={{ gridTemplateColumns: `repeat(${columnCount}, 1fr)` }}>
+      {grid.map((row, rowIndex) =>
+        row.map((tile, colIndex) => {
+          const isSelected = selectedPath.some((pos) => pos.row === rowIndex && pos.col === colIndex);
+          const isLast = selectedPath[selectedPath.length - 1]?.row === rowIndex &&
+            selectedPath[selectedPath.length - 1]?.col === colIndex;
+          return (
+            <Tile
+              key={`${rowIndex}-${colIndex}`}
+              tile={tile}
+              onSelect={() => onSelect(rowIndex, colIndex)}
+              isSelected={isSelected}
+              isLastSelected={isLast}
+            />
+          );
+        })
+      )}
+    </div>
+  );
+}
+
+export default Board;

--- a/src/components/Controls.jsx
+++ b/src/components/Controls.jsx
@@ -1,0 +1,22 @@
+import './controls.css';
+
+function Controls({ onSubmit, onUndo, onReset, onPauseToggle, isPaused, canSubmit }) {
+  return (
+    <div className="controls">
+      <button type="button" onClick={onUndo} disabled={!canSubmit}>
+        Undo
+      </button>
+      <button type="button" onClick={onSubmit} disabled={!canSubmit}>
+        Submit Path
+      </button>
+      <button type="button" onClick={onPauseToggle}>
+        {isPaused ? 'Resume' : 'Pause'}
+      </button>
+      <button type="button" onClick={onReset}>
+        Reset
+      </button>
+    </div>
+  );
+}
+
+export default Controls;

--- a/src/components/HUD.jsx
+++ b/src/components/HUD.jsx
@@ -1,0 +1,64 @@
+import classNames from '../utils/classNames.js';
+import './hud.css';
+
+function HUD({
+  score,
+  bestScore,
+  level,
+  bestLevel,
+  target,
+  runningSum,
+  timeLeft,
+  streak,
+  required,
+  solvedCount,
+  isPaused,
+  shake
+}) {
+  return (
+    <div className={classNames('hud', { shake })}>
+      <div className="hud-row">
+        <div className="hud-item">
+          <span className="label">Score</span>
+          <span className="value">{score}</span>
+        </div>
+        <div className="hud-item">
+          <span className="label">Best</span>
+          <span className="value">{bestScore}</span>
+        </div>
+        <div className="hud-item">
+          <span className="label">Level</span>
+          <span className="value">{level}</span>
+        </div>
+        <div className="hud-item">
+          <span className="label">Record Level</span>
+          <span className="value">{bestLevel}</span>
+        </div>
+      </div>
+      <div className="hud-row">
+        <div className="hud-item target">
+          <span className="label">Target</span>
+          <span className="value">{target}</span>
+        </div>
+        <div className="hud-item sum">
+          <span className="label">Current Sum</span>
+          <span className="value">{runningSum}</span>
+        </div>
+        <div className="hud-item">
+          <span className="label">Streak</span>
+          <span className="value">{streak}</span>
+        </div>
+        <div className="hud-item">
+          <span className="label">Solved</span>
+          <span className="value">{solvedCount}/{required}</span>
+        </div>
+        <div className="hud-item timer">
+          <span className="label">{isPaused ? 'Paused' : 'Time Left'}</span>
+          <span className="value">{timeLeft}s</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default HUD;

--- a/src/components/Tile.jsx
+++ b/src/components/Tile.jsx
@@ -1,0 +1,39 @@
+import classNames from '../utils/classNames.js';
+import './tile.css';
+
+function Tile({ tile, onSelect, isSelected, isLastSelected }) {
+  const handleClick = () => {
+    if (tile.locked) {
+      return;
+    }
+    onSelect();
+  };
+
+  const handleTouch = (event) => {
+    event.preventDefault();
+    handleClick();
+  };
+
+  const displayValue = tile.locked ? '🔒' : tile.value;
+
+  return (
+    <button
+      type="button"
+      className={classNames('tile', {
+        selected: isSelected,
+        last: isLastSelected,
+        negative: tile.value < 0,
+        bonus: tile.multiplier > 1,
+        locked: tile.locked
+      })}
+      onClick={handleClick}
+      onTouchStart={handleTouch}
+      disabled={tile.locked}
+    >
+      <span>{displayValue}</span>
+      {tile.multiplier > 1 && !tile.locked ? <span className="multiplier">x{tile.multiplier}</span> : null}
+    </button>
+  );
+}
+
+export default Tile;

--- a/src/components/board.css
+++ b/src/components/board.css
@@ -1,0 +1,12 @@
+.board {
+  display: grid;
+  gap: 8px;
+  margin: 24px auto;
+  max-width: 560px;
+}
+
+@media (max-width: 640px) {
+  .board {
+    gap: 6px;
+  }
+}

--- a/src/components/controls.css
+++ b/src/components/controls.css
@@ -1,0 +1,38 @@
+.controls {
+  display: flex;
+  justify-content: center;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-top: 16px;
+}
+
+.controls button {
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: none;
+  background: #0b4f6c;
+  color: #ffffff;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+.controls button:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 8px 16px rgba(15, 52, 96, 0.2);
+}
+
+.controls button:disabled {
+  background: #94a3b8;
+  cursor: not-allowed;
+}
+
+@media (max-width: 640px) {
+  .controls {
+    gap: 8px;
+  }
+
+  .controls button {
+    flex: 1 1 calc(50% - 8px);
+  }
+}

--- a/src/components/hud.css
+++ b/src/components/hud.css
@@ -1,0 +1,73 @@
+.hud {
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: 0 10px 20px rgba(15, 52, 96, 0.12);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  transition: transform 0.2s ease;
+}
+
+.hud.shake {
+  animation: shake 0.4s;
+}
+
+.hud-row {
+  display: flex;
+  justify-content: space-around;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.hud-item {
+  min-width: 120px;
+  padding: 12px;
+  border-radius: 12px;
+  background: #f0f4f8;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.hud-item.target {
+  background: #ffedd5;
+}
+
+.hud-item.sum {
+  background: #e0f2fe;
+}
+
+.hud-item.timer {
+  background: #fde68a;
+}
+
+.label {
+  font-size: 0.75rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #475569;
+}
+
+.value {
+  font-size: 1.35rem;
+  font-weight: 700;
+}
+
+@keyframes shake {
+  0% { transform: translateX(0); }
+  25% { transform: translateX(-6px); }
+  50% { transform: translateX(6px); }
+  75% { transform: translateX(-3px); }
+  100% { transform: translateX(0); }
+}
+
+@media (max-width: 640px) {
+  .hud-item {
+    min-width: 100px;
+  }
+
+  .value {
+    font-size: 1.1rem;
+  }
+}

--- a/src/components/tile.css
+++ b/src/components/tile.css
@@ -1,0 +1,61 @@
+.tile {
+  border: none;
+  border-radius: 12px;
+  background: linear-gradient(145deg, #ffffff, #e3edf7);
+  box-shadow: 0 8px 16px rgba(15, 52, 96, 0.15);
+  color: #0b4f6c;
+  min-height: 72px;
+  font-size: 1.5rem;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  touch-action: manipulation;
+}
+
+.tile:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 22px rgba(15, 52, 96, 0.18);
+}
+
+.tile.selected {
+  background: linear-gradient(145deg, #ffe8d6, #ffd5b5);
+  color: #802b00;
+}
+
+.tile.last {
+  outline: 4px solid #ff7f50;
+}
+
+.tile.negative {
+  color: #c81d25;
+}
+
+.tile.bonus {
+  background: linear-gradient(145deg, #daf7dc, #b3f2be);
+  color: #0c5b2e;
+}
+
+.tile.locked {
+  background: #d4d8dd;
+  color: #4b5563;
+  box-shadow: inset 0 0 0 2px rgba(75, 85, 99, 0.2);
+}
+
+.tile .multiplier {
+  position: absolute;
+  bottom: 8px;
+  right: 12px;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: inherit;
+}
+
+@media (max-width: 640px) {
+  .tile {
+    min-height: 60px;
+    font-size: 1.2rem;
+  }
+}

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App.jsx';
+import './styles/index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -1,0 +1,22 @@
+.app {
+  max-width: 960px;
+  margin: 0 auto;
+  padding: 24px 16px 48px;
+  text-align: center;
+}
+
+.app h1 {
+  margin-bottom: 16px;
+  font-size: 2.5rem;
+  color: #0b4f6c;
+}
+
+@media (max-width: 640px) {
+  .app {
+    padding: 16px 8px 32px;
+  }
+
+  .app h1 {
+    font-size: 2rem;
+  }
+}

--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -1,0 +1,18 @@
+:root {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  color: #1f2933;
+  background-color: #f5f7fa;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+a {
+  color: inherit;
+}

--- a/src/utils/__tests__/generator.test.js
+++ b/src/utils/__tests__/generator.test.js
@@ -1,0 +1,53 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { generatePuzzle } from '../generator.js';
+
+const mockConfig = {
+  gridSize: 4,
+  targetRange: [8, 15],
+  timeLimit: 90,
+  requiredSolutions: 5,
+  features: {
+    negative: false,
+    locked: true,
+    bonus: true
+  }
+};
+
+describe('generator', () => {
+  it('creates a board with at least one valid path', () => {
+    const { grid, target, solutionPath } = generatePuzzle(mockConfig);
+    assert.ok(solutionPath.length > 0);
+    const seen = new Set();
+    let total = 0;
+    solutionPath.forEach((pos, index) => {
+      const key = `${pos.row},${pos.col}`;
+      assert.equal(seen.has(key), false);
+      seen.add(key);
+      if (index > 0) {
+        const prev = solutionPath[index - 1];
+        const rowDiff = Math.abs(prev.row - pos.row);
+        const colDiff = Math.abs(prev.col - pos.col);
+        assert.ok(rowDiff <= 1 && colDiff <= 1);
+      }
+      const tile = grid[pos.row][pos.col];
+      assert.equal(tile.locked, false);
+      total += tile.value * (tile.multiplier || 1);
+    });
+    assert.equal(total, target);
+  });
+
+  it('respects locked tiles and bonus multipliers', () => {
+    const { grid } = generatePuzzle(mockConfig);
+    let lockedCount = 0;
+    let bonusCount = 0;
+    grid.forEach((row) => {
+      row.forEach((tile) => {
+        if (tile.locked) lockedCount += 1;
+        if (!tile.locked && tile.multiplier > 1) bonusCount += 1;
+      });
+    });
+    assert.ok(lockedCount > 0);
+    assert.ok(bonusCount > 0);
+  });
+});

--- a/src/utils/__tests__/pathUtils.test.js
+++ b/src/utils/__tests__/pathUtils.test.js
@@ -1,0 +1,38 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { calculatePathSum, isAdjacent, isValidNextSelection } from '../pathUtils.js';
+
+describe('path utils', () => {
+  it('determines adjacency including diagonals', () => {
+    assert.equal(isAdjacent({ row: 0, col: 0 }, { row: 0, col: 1 }), true);
+    assert.equal(isAdjacent({ row: 0, col: 0 }, { row: 1, col: 1 }), true);
+    assert.equal(isAdjacent({ row: 0, col: 0 }, { row: 2, col: 0 }), false);
+    assert.equal(isAdjacent({ row: 0, col: 0 }, { row: 0, col: 0 }), false);
+  });
+
+  it('validates next selection against previous', () => {
+    const last = { row: 2, col: 2 };
+    assert.equal(isValidNextSelection(last, { row: 3, col: 3 }), true);
+    assert.equal(isValidNextSelection(last, { row: 4, col: 2 }), false);
+  });
+
+  it('calculates running sum honoring multipliers and locked tiles', () => {
+    const grid = [
+      [
+        { value: 2, multiplier: 1, locked: false },
+        { value: -1, multiplier: 2, locked: false }
+      ],
+      [
+        { value: 5, multiplier: 1, locked: true },
+        { value: 3, multiplier: 1, locked: false }
+      ]
+    ];
+    const path = [
+      { row: 0, col: 0 },
+      { row: 0, col: 1 },
+      { row: 1, col: 0 },
+      { row: 1, col: 1 }
+    ];
+    assert.equal(calculatePathSum(path, grid), 2 + -1 * 2 + 0 + 3);
+  });
+});

--- a/src/utils/classNames.js
+++ b/src/utils/classNames.js
@@ -1,0 +1,16 @@
+export default function classNames(...inputs) {
+  return inputs
+    .flatMap((input) => {
+      if (!input) return [];
+      if (typeof input === 'string') return [input];
+      if (Array.isArray(input)) return input;
+      if (typeof input === 'object') {
+        return Object.entries(input)
+          .filter(([, value]) => Boolean(value))
+          .map(([key]) => key);
+      }
+      return [];
+    })
+    .join(' ')
+    .trim();
+}

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -58,28 +58,35 @@ function valueBounds(features) {
 function generateSolutionNumbers(pathLength, levelConfig) {
   const { min, max } = valueBounds(levelConfig.features);
   const [targetMin, targetMax] = levelConfig.targetRange;
+
   for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
+    const target = randomInt(targetMin, targetMax);
     const numbers = [];
-    let runningSum = 0;
-    for (let i = 0; i < pathLength - 1; i += 1) {
-      const value = randomInt(min, max);
+    let remaining = target;
+    let valid = true;
+
+    for (let index = 0; index < pathLength; index += 1) {
+      const slotsLeft = pathLength - index;
+      const minPossible = min * (slotsLeft - 1);
+      const maxPossible = max * (slotsLeft - 1);
+      const low = Math.max(min, remaining - maxPossible);
+      const high = Math.min(max, remaining - minPossible);
+
+      if (low > high) {
+        valid = false;
+        break;
+      }
+
+      const value = index === pathLength - 1 ? remaining : randomInt(low, high);
       numbers.push(value);
-      runningSum += value;
+      remaining -= value;
     }
-    const remainingMin = targetMin - runningSum;
-    const remainingMax = targetMax - runningSum;
-    const finalMin = Math.max(min, remainingMin);
-    const finalMax = Math.min(max, remainingMax);
-    if (finalMin > finalMax) {
-      continue;
-    }
-    const finalValue = randomInt(finalMin, finalMax);
-    numbers.push(finalValue);
-    const total = runningSum + finalValue;
-    if (total >= targetMin && total <= targetMax) {
-      return { numbers, target: total };
+
+    if (valid && remaining === 0) {
+      return { numbers, target };
     }
   }
+
   throw new Error('Failed to generate solution numbers');
 }
 

--- a/src/utils/generator.js
+++ b/src/utils/generator.js
@@ -1,0 +1,172 @@
+import { isAdjacent } from './pathUtils.js';
+
+const MAX_ATTEMPTS = 200;
+
+function randomInt(min, max) {
+  return Math.floor(Math.random() * (max - min + 1)) + min;
+}
+
+function buildNeighbors(size, cell) {
+  const neighbors = [];
+  for (let dr = -1; dr <= 1; dr += 1) {
+    for (let dc = -1; dc <= 1; dc += 1) {
+      if (dr === 0 && dc === 0) continue;
+      const nr = cell.row + dr;
+      const nc = cell.col + dc;
+      if (nr >= 0 && nr < size && nc >= 0 && nc < size) {
+        neighbors.push({ row: nr, col: nc });
+      }
+    }
+  }
+  return neighbors;
+}
+
+function generateSolutionPath(size) {
+  const minLength = Math.min(4, size + 1);
+  const maxLength = Math.min(size * 2, size * size);
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
+    const path = [];
+    const used = new Set();
+    const start = { row: randomInt(0, size - 1), col: randomInt(0, size - 1) };
+    path.push(start);
+    used.add(`${start.row},${start.col}`);
+    const desiredLength = randomInt(minLength, Math.max(minLength, maxLength));
+    while (path.length < desiredLength) {
+      const last = path[path.length - 1];
+      const neighbors = buildNeighbors(size, last).filter((pos) => !used.has(`${pos.row},${pos.col}`));
+      if (neighbors.length === 0) {
+        break;
+      }
+      const next = neighbors[randomInt(0, neighbors.length - 1)];
+      path.push(next);
+      used.add(`${next.row},${next.col}`);
+    }
+    if (path.length >= minLength) {
+      return path;
+    }
+  }
+  throw new Error('Failed to generate solution path');
+}
+
+function valueBounds(features) {
+  if (features.negative) {
+    return { min: -5, max: 9 };
+  }
+  return { min: 1, max: 9 };
+}
+
+function generateSolutionNumbers(pathLength, levelConfig) {
+  const { min, max } = valueBounds(levelConfig.features);
+  const [targetMin, targetMax] = levelConfig.targetRange;
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
+    const numbers = [];
+    let runningSum = 0;
+    for (let i = 0; i < pathLength - 1; i += 1) {
+      const value = randomInt(min, max);
+      numbers.push(value);
+      runningSum += value;
+    }
+    const remainingMin = targetMin - runningSum;
+    const remainingMax = targetMax - runningSum;
+    const finalMin = Math.max(min, remainingMin);
+    const finalMax = Math.min(max, remainingMax);
+    if (finalMin > finalMax) {
+      continue;
+    }
+    const finalValue = randomInt(finalMin, finalMax);
+    numbers.push(finalValue);
+    const total = runningSum + finalValue;
+    if (total >= targetMin && total <= targetMax) {
+      return { numbers, target: total };
+    }
+  }
+  throw new Error('Failed to generate solution numbers');
+}
+
+function pickRandomCells(size, count, excludedSet) {
+  const available = [];
+  for (let row = 0; row < size; row += 1) {
+    for (let col = 0; col < size; col += 1) {
+      const key = `${row},${col}`;
+      if (!excludedSet.has(key)) {
+        available.push({ row, col });
+      }
+    }
+  }
+  for (let i = available.length - 1; i > 0; i -= 1) {
+    const j = randomInt(0, i);
+    [available[i], available[j]] = [available[j], available[i]];
+  }
+  return available.slice(0, count).map(({ row, col }) => `${row},${col}`);
+}
+
+function createTile(value, overrides = {}) {
+  return {
+    value,
+    multiplier: 1,
+    locked: false,
+    ...overrides
+  };
+}
+
+export function generatePuzzle(levelConfig) {
+  const size = levelConfig.gridSize;
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
+    const solutionPath = generateSolutionPath(size);
+    const { numbers, target } = generateSolutionNumbers(solutionPath.length, levelConfig);
+    const solutionSet = new Set(solutionPath.map((pos) => `${pos.row},${pos.col}`));
+
+    const lockedCount = levelConfig.features.locked ? Math.max(1, Math.floor(size / 2)) : 0;
+    const lockedCells = new Set(pickRandomCells(size, lockedCount, solutionSet));
+
+    const bonusCount = levelConfig.features.bonus ? Math.max(1, Math.floor(size / 2)) : 0;
+    const excludedForBonus = new Set([...solutionSet, ...lockedCells]);
+    const bonusCells = new Set(pickRandomCells(size, bonusCount, excludedForBonus));
+
+    const grid = Array.from({ length: size }, () => Array.from({ length: size }, () => createTile(0)));
+    const { min, max } = valueBounds(levelConfig.features);
+
+    for (let row = 0; row < size; row += 1) {
+      for (let col = 0; col < size; col += 1) {
+        const key = `${row},${col}`;
+        if (solutionSet.has(key)) {
+          const index = solutionPath.findIndex((pos) => pos.row === row && pos.col === col);
+          grid[row][col] = createTile(numbers[index]);
+          continue;
+        }
+        if (lockedCells.has(key)) {
+          grid[row][col] = createTile(0, { locked: true });
+          continue;
+        }
+        let value = randomInt(min, max);
+        if (!levelConfig.features.negative && value < 0) {
+          value = Math.abs(value);
+        }
+        const isBonus = bonusCells.has(key);
+        grid[row][col] = createTile(value, { multiplier: isBonus ? 2 : 1 });
+      }
+    }
+
+    if (validateSolution(grid, solutionPath, target)) {
+      return { grid, target, solutionPath };
+    }
+  }
+  throw new Error('Unable to generate valid puzzle');
+}
+
+function validateSolution(grid, path, target) {
+  let total = 0;
+  for (let i = 1; i < path.length; i += 1) {
+    if (!isAdjacent(path[i - 1], path[i])) {
+      return false;
+    }
+  }
+  for (const pos of path) {
+    const tile = grid[pos.row]?.[pos.col];
+    if (!tile || tile.locked) {
+      return false;
+    }
+    total += tile.value * (tile.multiplier || 1);
+  }
+  return total === target;
+}

--- a/src/utils/pathUtils.js
+++ b/src/utils/pathUtils.js
@@ -1,0 +1,23 @@
+export function isAdjacent(a, b) {
+  const rowDiff = Math.abs(a.row - b.row);
+  const colDiff = Math.abs(a.col - b.col);
+  return rowDiff <= 1 && colDiff <= 1 && !(rowDiff === 0 && colDiff === 0);
+}
+
+export function isValidNextSelection(last, next) {
+  if (!last) {
+    return true;
+  }
+  return isAdjacent(last, next);
+}
+
+export function calculatePathSum(path, grid) {
+  return path.reduce((total, pos) => {
+    const tile = grid[pos.row]?.[pos.col];
+    if (!tile || tile.locked) {
+      return total;
+    }
+    const value = tile.value * (tile.multiplier || 1);
+    return total + value;
+  }, 0);
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom'
+  }
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,8 @@
 import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  plugins: [react()],
   test: {
     environment: 'jsdom'
   }


### PR DESCRIPTION
## Summary
- bootstrap a React-based Connect Numbers puzzle with level progression, scoring, pause/reset, and persistence
- implement board, tile, HUD, and controls components with styling, touch interactions, and local classNames helper
- add puzzle generator/validator utilities and node:test coverage for adjacency and guaranteed target paths

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68db967aea088325a6efa7528ee47394